### PR TITLE
Big patch

### DIFF
--- a/libwav.h
+++ b/libwav.h
@@ -32,7 +32,6 @@ union _wav_chunk_content
 {
 	wav_header header;
 	wav_format format;
-	unsigned char data[WAV_CHUNK_LEN];
 };
 
 struct _wav_chunk

--- a/tools/wav_info/wav_info.c
+++ b/tools/wav_info/wav_info.c
@@ -12,7 +12,7 @@ static void print_info (char *filename)
 	if (f == NULL)
 	{
 		printf ("Error: Couldn't open the file!\n");
-		return -1;
+		return;
 	}
 	
 	wav_read (&wavfile, f);


### PR DESCRIPTION
This fixed a bug that allocates double the amount of memory required for a file due to a wrong way of calculating it.
Additionally a wrong return type was fixed, as well as the unrequited variable data from the structure _wav_chunk_content was removed.